### PR TITLE
Update MineFarmManager.php

### DIFF
--- a/src/ifteam/SimpleArea/database/minefarm/MineFarmManager.php
+++ b/src/ifteam/SimpleArea/database/minefarm/MineFarmManager.php
@@ -85,7 +85,6 @@ class MineFarmManager {
 				$this->alert ( $player, "not-enough-money" );
 				return false;
 			}
-			$this->economy->reduceMoney ( $player, $price );
 		}
 		$areaHoldLimit = $this->whiteWorldProvider->get ( "minefarm" )->getAreaHoldLimit ();
 		$userHoldCount = count ( $this->properties->getUserProperties ( $player->getName (), "minefarm" ) );
@@ -94,6 +93,9 @@ class MineFarmManager {
 				$this->alert ( $player, $this->get ( "no-more-buying-area" ) );
 				return false;
 			}
+		}
+		if ($this->economy !== null and ! $player->isop ()) {
+			$this->economy->reduceMoney ( $player, $price );
 		}
 		$areaId = $this->mineFarmLoader->addMineFarm ( $player );
 		$this->message ( $player, $areaId . " " . $this->get ( "minefarm-buying-that-minefarm" ) );


### PR DESCRIPTION
마인팜 최대보유수보다 보유한 마인팜이 많을때 구매 취소되도 돈 빠져나가는 오류 수정
